### PR TITLE
File generation for SsdStandalone and RandomPartitioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+iris/target
+iris/src/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 iris/target
 iris/src/target
+iris/scripts/out

--- a/iris/scripts/Dockerfile
+++ b/iris/scripts/Dockerfile
@@ -1,10 +1,7 @@
-# Use an official Python runtime as a parent image
-FROM python:3.9-slim
+FROM python:3.11-slim
 
-# Set the working directory in the container
 WORKDIR /app
 
-# Install dependencies (FAISS, NumPy, etc.)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -15,10 +12,8 @@ RUN apt-get update && \
 # Install Python dependencies
 RUN pip install --no-cache-dir faiss-cpu numpy
 
-# Copy the current directory contents into the container at /app
 COPY compute_partitions.py /app
 COPY data /app
 
-# Specify the Python file to run (replace 'your_script.py' with your Python file name)
-CMD ["python", "compute_partitions.py"]
+CMD ["python", "compute_partitions.py", ""]
 

--- a/iris/scripts/Dockerfile
+++ b/iris/scripts/Dockerfile
@@ -15,5 +15,7 @@ RUN pip install --no-cache-dir faiss-cpu numpy
 COPY compute_partitions.py /app
 COPY data /app
 
-CMD ["python", "compute_partitions.py", ""]
+# Docker command should be specified when running, i.e.
+# 
+# docker run -v ./outdir:/app/outdir compute_partitions python compute_partitions.py deep1k --out outdir 
 

--- a/iris/scripts/compute_partitions.py
+++ b/iris/scripts/compute_partitions.py
@@ -10,29 +10,17 @@ from enum import Enum, auto
 
 # This represents all the architectures and balancing strategies we will test against
 class Partitions(Enum):
-    SSD1N = 1
-    SSD2N = 2
-    SSD5N = 3
-    SSD10N = 4
-    Random1N = 5
-    Random2N = 6
-    Random5N = 7
-    Random10N = 8
-    BalancedHNSW1N = 9 # check when you get benefits -> maybe 20 nodes
-    BalancedHNSW2N = 10
-    BalancedHNSW5N = 11
-    BalancedHNSW10N = 12
-    BalancedLSH1N = 13
-    BalancedLSH2N = 14
-    BalancedLSH5N = 15
-    BalancedLSH10N = 16
+    SsdReplicated = 0
+    RandomPartitions = 1
+    BalancedHnsw = 2
+    BalancedLsh = 3
 
 def process_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--out", default="./", help="The path to the output directory")
-    parser.add_argument("--szsufs", default=["1M", "10M", "100M"], nargs="*", help="The target sizes")
-    parser.add_argument("--base_filename", default="./data/deep1M/deep1M_learn.fvecs", help="The path to the base veectors")
-    parser.add_argument("--query_filename", default="./data/deep1M/deep1M_query.fvecs", help="The path to the query vectors")
+    parser.add_argument("name", type=str, help="The name for the outputted dataset")
+    parser.add_argument("--out", default="./out/", help="The path to the output directory")
+    parser.add_argument("--architecture", default=["ssd", "random", "hnsw", "lsh"], nargs="*", help="The architecture according to which to partition the vector set.")
+    parser.add_argument("--db", default="./data/deep1M/deep1M_query.fvecs", help="The path to the vector set that you want to partition")
     return parser.parse_args()
 
 # Note: This is in memory. Use ivecs_mmap for the same functionality but with 
@@ -83,79 +71,77 @@ def partition_to_nodes(data, num_nodes=4):
     """
     nb = data.shape[0]
     block_size = nb // num_nodes  # Determine the size of each partition
-    
+
     partitions = []
-    
+
     for node_id in range(num_nodes):
         start_idx = node_id * block_size
         # If last node, include all remaining vectors
         end_idx = nb if node_id == num_nodes - 1 else (node_id + 1) * block_size
         partitions.append(data[start_idx:end_idx])  # Partitioned data block
-    
+
     return partitions 
 
 
-def compute_SSD(data, num_partitions):
-    '''
-    We use this function to run experiments on
-    - Single Node baseline where num_partitions = 1
-    - Simple replication where, for n nodes, the data is simply copied
-    into each of the n nodes.
-    '''
-    # Do we do our own filesystem to store this in?
-    # Do we care if for smaller datasets this is effectively all in cache
-    nodes = []
-    for i in range(num_partitions):
-        # {architecture}_{clustersize}nodes_node{nodenumber}.fvecs
-        nodes.append(np.copy(data))
-    pass
-
 def compute_random_partitions(data, num_partitions):
-    for i in range(len(data)):
-
+    # for i in range(len(data)):
     np.random.shuffle(data)
-    
     return np.array_split(data, num_partitions)
 
 def compute_balanced_partitions(data, num_partitions):
-
+    print("Computing {} balanced partitions...", num_partitions)
     pass
 
-def compute_partitions(data, kind, how_many):
-    match kind:
-        case Partitions.SSD:
-            compute_SSD(data, how_many)
-        case Partitions.Random: # 2 nodes, 5 nodes
+def get_fname(architecture: Partitions, how_many: int, node_num: int, dataset_name: str):
+    if architecture is Partitions.SsdReplicated:
+        return f"{dataset_name}_{architecture.name}.fvecs"
+
+    return f"{dataset_name}_{architecture.name}_{how_many}nodes_node{node_num}.fvecs"
+
+def mkdir_p(directory_path):
+    Path(directory_path).mkdir(parents=True, exist_ok=True)
+    print("Created {}.", directory_path)
+
+def compute_partitions(data, how_many: int, schema: Partitions, out_dir: str, dataset_name: str):
+    match schema:
+
+        case Partitions.SsdReplicated:
+            partition_name = get_fname(schema, how_many, 1, dataset_name)
+            fvecs_write(Path(out_dir) / Path(partition_name), data)
+            print("Wrote {}.", partition_name)
+            # TODO: just create a file with the main fvecs
+        case Partitions.RandomPartitions: 
             compute_random_partitions(data, how_many)
-        case Partitions.Balanced:
+        case Partitions.BalancedHnsw:
+            compute_balanced_partitions(data, how_many)
+        case Partitions.BalancedLsh:
             compute_balanced_partitions(data, how_many)
         case _:
             print("Error: No such partition")
-    pass
-
 
 if __name__ == '__main__':
     args = process_args()
 
-    for szsuf in args.szsufs:
-        print("Deep{}:".format(szsuf))
-        dbsize = {"1M": 1000000, "10M": 10000000, "100M": 100000000}[szsuf]
+    mkdir_p(args.out)
 
-        # xb = mmap_fvecs('deep1b/base.fvecs')
-        # xq = mmap_fvecs('deep1b/deep1B_queries.fvecs')
-        # xt = mmap_fvecs('deep1b/learn.fvecs')
-        # # deep1B's train is is outrageously big
-        # xt = xt[:10 * 1000 * 1000]
-        # 
+    for arch in args.architecture:
+        print("Calculating partitions for {}:".format(arch))
+        partition_schema = {
+            "ssd": Partitions.SsdReplicated,
+            "random": Partitions.RandomPartitions,
+            "lsh": Partitions.BalancedLsh,
+            "hnsw": Partitions.BalancedHnsw,
+        }[arch]
 
-        xb = fvecs_mmap(args.base_filename)
-        xq = fvecs_read(args.query_filename)
+        base_db = fvecs_mmap(args.db)
+        base_db = np.ascontiguousarray(base_db, dtype='float32')
 
-        xb = np.ascontiguousarray(xb[:dbsize], dtype='float32')
+        print("Base db shape: {}", base_db.shape)
 
-        gt_fname = str(Path(args.out) / "deep{}_groundtruth.ivecs".format(szsuf))
-        # gt = ivecs_read('deep1b/deep1B_groundtruth.ivecs') Added from FAISS
-        gt = do_compute_gt(xb, xq, topk=100)
+        clustersizes = [1, 2, 5, 10]
+        for how_many in clustersizes:
+            compute_partitions(base_db, how_many, partition_schema, args.out, args.name)
 
-        ivecs_write(gt_fname, gt)
+        # out= str(Path(args.out) / "deep{}_groundtruth.ivecs".format(szsuf))
+        # ivecs_write(gt_fname, gt)
 

--- a/iris/scripts/compute_partitions.py
+++ b/iris/scripts/compute_partitions.py
@@ -6,6 +6,26 @@ import faiss
 import numpy as np
 import argparse
 from pathlib import Path
+from enum import Enum, auto
+
+# This represents all the architectures and balancing strategies we will test against
+class Partitions(Enum):
+    SSD1N = 1
+    SSD2N = 2
+    SSD5N = 3
+    SSD10N = 4
+    Random1N = 5
+    Random2N = 6
+    Random5N = 7
+    Random10N = 8
+    BalancedHNSW1N = 9 # check when you get benefits -> maybe 20 nodes
+    BalancedHNSW2N = 10
+    BalancedHNSW5N = 11
+    BalancedHNSW10N = 12
+    BalancedLSH1N = 13
+    BalancedLSH2N = 14
+    BalancedLSH5N = 15
+    BalancedLSH10N = 16
 
 def process_args():
     parser = argparse.ArgumentParser()
@@ -15,7 +35,8 @@ def process_args():
     parser.add_argument("--query_filename", default="./data/deep1M/deep1M_query.fvecs", help="The path to the query vectors")
     return parser.parse_args()
 
-
+# Note: This is in memory. Use ivecs_mmap for the same functionality but with 
+# memmap to be able to work with larger 
 def ivecs_read(fname):
     a = np.fromfile(fname, dtype='int32')
     d = a[0]
@@ -25,7 +46,8 @@ def ivecs_read(fname):
 def fvecs_read(fname):
     return ivecs_read(fname).view('float32')
 
-
+# This is what should be used for datasets that cannot be loaded into memory
+# i.e., greater than 64GBs
 def ivecs_mmap(fname):
     a = np.memmap(fname, dtype='int32', mode='r')
     d = a[0]
@@ -55,6 +77,62 @@ def do_compute_gt(xb, xq, topk=100):
     _, ids = index.search(x=xq, k=topk)
     return ids.astype('int32')
 
+def partition_to_nodes(data, num_nodes=4):
+    """
+    Partitions the data into 'num_nodes' equal parts and assigns to different nodes.
+    """
+    nb = data.shape[0]
+    block_size = nb // num_nodes  # Determine the size of each partition
+    
+    partitions = []
+    
+    for node_id in range(num_nodes):
+        start_idx = node_id * block_size
+        # If last node, include all remaining vectors
+        end_idx = nb if node_id == num_nodes - 1 else (node_id + 1) * block_size
+        partitions.append(data[start_idx:end_idx])  # Partitioned data block
+    
+    return partitions 
+
+
+def compute_SSD(data, num_partitions):
+    '''
+    We use this function to run experiments on
+    - Single Node baseline where num_partitions = 1
+    - Simple replication where, for n nodes, the data is simply copied
+    into each of the n nodes.
+    '''
+    # Do we do our own filesystem to store this in?
+    # Do we care if for smaller datasets this is effectively all in cache
+    nodes = []
+    for i in range(num_partitions):
+        # {architecture}_{clustersize}nodes_node{nodenumber}.fvecs
+        nodes.append(np.copy(data))
+    pass
+
+def compute_random_partitions(data, num_partitions):
+    for i in range(len(data)):
+
+    np.random.shuffle(data)
+    
+    return np.array_split(data, num_partitions)
+
+def compute_balanced_partitions(data, num_partitions):
+
+    pass
+
+def compute_partitions(data, kind, how_many):
+    match kind:
+        case Partitions.SSD:
+            compute_SSD(data, how_many)
+        case Partitions.Random: # 2 nodes, 5 nodes
+            compute_random_partitions(data, how_many)
+        case Partitions.Balanced:
+            compute_balanced_partitions(data, how_many)
+        case _:
+            print("Error: No such partition")
+    pass
+
 
 if __name__ == '__main__':
     args = process_args()
@@ -63,13 +141,21 @@ if __name__ == '__main__':
         print("Deep{}:".format(szsuf))
         dbsize = {"1M": 1000000, "10M": 10000000, "100M": 100000000}[szsuf]
 
+        # xb = mmap_fvecs('deep1b/base.fvecs')
+        # xq = mmap_fvecs('deep1b/deep1B_queries.fvecs')
+        # xt = mmap_fvecs('deep1b/learn.fvecs')
+        # # deep1B's train is is outrageously big
+        # xt = xt[:10 * 1000 * 1000]
+        # 
+
         xb = fvecs_mmap(args.base_filename)
         xq = fvecs_read(args.query_filename)
 
         xb = np.ascontiguousarray(xb[:dbsize], dtype='float32')
 
         gt_fname = str(Path(args.out) / "deep{}_groundtruth.ivecs".format(szsuf))
-
+        # gt = ivecs_read('deep1b/deep1B_groundtruth.ivecs') Added from FAISS
         gt = do_compute_gt(xb, xq, topk=100)
+
         ivecs_write(gt_fname, gt)
 

--- a/iris/scripts/readme.org
+++ b/iris/scripts/readme.org
@@ -1,4 +1,4 @@
-* Scripts to download and partition vectors
+* Download and partition vectors
 
 ** Download the Deep1M dataset and unzip
 #+begin_src
@@ -9,3 +9,9 @@ wget https://www.dropbox.com/scl/fo/9q8tah1kkdwqszjftrch1/AF_nrjGv9j6AK59I7BIVyC
 tar -xvzf deep1M.tar.gz
 #+end_src
 
+* Run the partitioning
+#+begin_src
+export DATASET_NAME=deep1k
+export OUTDIR=outdir
+docker run -v ./data:/app/data -v ./outdir:/app/outdir compute_partitions python compute_partitions.py $DATASET_NAME --out $OUTDIR 
+#+end_src


### PR DESCRIPTION
resolves #7.

`SsdStandalone` only requires one fvecs file (as this is duplicated on all nodes). 
`RandomPartitioning` uses that same file for the 1 node architecture, and then requires 2 + 5 + 10 files for the remaining three architectures.